### PR TITLE
Improve project files

### DIFF
--- a/1.6/Base/Source/BigSmallFramework/BigAndSmall.csproj
+++ b/1.6/Base/Source/BigSmallFramework/BigAndSmall.csproj
@@ -16,20 +16,32 @@
     <DebugType>none</DebugType>
     
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-		<RimWorldPath Condition="'$(RimWorldPath)' == '' AND '$(OS)' == 'Windows_NT'">..\..\..\..\..\..\RimWorldWin64_Data/Managed</RimWorldPath>
-    <RimWorldPath Condition="'$(RimWorldPath)' == '' AND '$(OS)' != 'Windows_NT'">..\..\..\..\..\..\RimWorldLinux_Data/Managed</RimWorldPath>
     <NoStdLib>true</NoStdLib>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="$(RimWorldPath)/*.dll">
-      <Private>False</Private>
-    </Reference>
-    <PackageReference Include="Krafs.Publicizer" Version="2.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Krafs.Rimworld.Ref">
+      <Version>1.6.*</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="RimWorld.MultiplayerAPI" Version="0.5.0" />
+
+    <PackageReference Include="Krafs.Publicizer">
+      <Version>2.3.*</Version>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+
+    <PackageReference Include="Zetrith.Prepatcher">
+      <Version>1.2.0</Version>
+    </PackageReference>
+
+    <PackageReference Include="Lib.Harmony">
+      <Version>2.3.6</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <Publicize Include="Assembly-CSharp:RimWorld.Pawn_GeneTracker.xenotype" />
     <Publicize Include="Assembly-CSharp:RimWorld.Pawn_GeneTracker.Notify_GenesChanged" />
     <Publicize Include="Assembly-CSharp:RimWorld.Pawn_GeneTracker.CheckForOverrides" />
@@ -58,12 +70,5 @@
     <Publicize Include="Assembly-CSharp:Verse.RaceProperties.nameGeneratorFemale" />
     <Publicize Include="Assembly-CSharp:Verse.PawnRenderNode.props" />
     <Publicize Include="Assembly-CSharp:Verse.RaceProperties.fleshType" />
-    
-    <PackageReference Include="Zetrith.Prepatcher" Version="1.2.0" />
-
-    <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\..\..\..\workshop\content\294100\2009463077\Current\Assemblies\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
 </Project>

--- a/1.6/Base/Source/EarlyPatchProject/BigAndSmall_Early.csproj
+++ b/1.6/Base/Source/EarlyPatchProject/BigAndSmall_Early.csproj
@@ -27,26 +27,30 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="$(RimWorldPath)/*.dll">
-      <Private>False</Private>
-    </Reference>
-    <PackageReference Include="Krafs.Publicizer" Version="2.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Krafs.Rimworld.Ref">
+      <Version>1.6.*</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="RimWorld.MultiplayerAPI" Version="0.5.0" />
-    <Publicize Include="Assembly-CSharp:RimWorld.ThingDefGenerator_Corpses.GenerateCorpseDef" />
-    <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\..\..\..\workshop\content\294100\2009463077\Current\Assemblies\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <!-- <PackageReference Include="Krafs.Publicizer" Version="2.*"/> -->
-    <!-- <PackageReference Include="Zetrith.Prepatcher" Version="1.*" /> -->
+
+    <PackageReference Include="Krafs.Publicizer">
+      <Version>2.3.*</Version>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+
+    <PackageReference Include="Lib.Harmony">
+      <Version>2.3.6</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\BigSmallFramework\BigAndSmall.csproj">
       <Project>{f0272df1-d703-495d-8f95-48d6bab3a0b9}</Project>
       <Name>BigAndSmall</Name>
     </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Publicize Include="Assembly-CSharp:RimWorld.ThingDefGenerator_Corpses.GenerateCorpseDef" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The changes introduced in this PR make the project build-able everywhere by not depending on local files or hardcoded paths.

- Uses RimWorld public references instead of local dlls.
- Removes unused reference to MultiplayerAPI.
- Organizes the project files.